### PR TITLE
Unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,13 @@ const account = await msafe.chainId();  // 1
 This method is used to sign the transaction and then submit it to the blockchain.  
 It takes two parameters:
 - `payload` - mandatory parameter containing the transaction body.
+  - For arguments of type vector, you can pass in an array.
+  - For `vector<u8>`, you can pass in `Uint8Array`.
+  - You can also pass in a BCS serialized transaction as payload(`Uint8Array`), which ignores option.
 - `option` - optional parameter that overrides transaction parameters.
-> - For arguments of type vector, you can pass in an array.
-> - For `vector<u8>`, you can pass in `Uint8Array`.
-> - You can also pass in a BCS serialized transaction as payload(`Uint8Array`), which ignores option.
 
-> **In current implementation, this function call never returns. This is because when a transaction is initiated, the dapp page will be closed and then the msafe page will be entered to collect signatures. We will optimize it in future releases.**
+
+> **In current implementation, this method call never returns. This is because when a transaction is initiated, the dapp page will be closed and then the msafe page will be entered to collect signatures. We will optimize it in future releases.**
 
 Example:
 ```typescript
@@ -135,7 +136,7 @@ Not supported for now.
 Not supported for now.
 
 ### Network Change Event
-This function is used to register the callback function for the network change event.
+This method is used to register the callback function for the network change event.
 
 Example:
 ```typescript
@@ -147,7 +148,7 @@ msafe.onChangeAccount((network:string)=>{
 ```
 
 ### Account Change Event
-This function is used to register the callback function for the account change event.
+This method is used to register the callback function for the account change event.
 
 Example:
 ```typescript
@@ -162,7 +163,7 @@ msafe.onChangeAccount((account:Account)=>{
 ## Use Aptos Wallet Adaptor
 The wallet adapter helps you to integrate many different wallets at once and use the same interface to interact with any supported wallet.
 
-Developed by Hippo team, main repository - https://github.com/hippospace/aptos-wallet-adapter.
+Here we give an example of using msafe wallet with the adaptor. For more details, see: https://github.com/hippospace/aptos-wallet-adapter.
 
 ### Install wallet adapter
 
@@ -173,6 +174,7 @@ npm install @manahippo/aptos-wallet-adapter
 ```
 
 ### Create wallet adapter
+Example:
 ```typescript
 import {
     WalletProvider,
@@ -185,6 +187,7 @@ const wallets = [
 ```
 
 ### Use wallet adapter
+Example:
 ```tsx
 import React from "react";
 import {
@@ -212,6 +215,7 @@ export default App;
 ```
 
 ### Use wallet adapter hooks
+Example:
 ```tsx
 import { useWallet, MsafeWalletName } from "@manahippo/aptos-wallet-adapter";
 
@@ -235,6 +239,7 @@ export function DAPP() {
 
 > **In current implementation, the function `signAndSubmitTransaction` never returns. This is because when a transaction is initiated, the dapp page will be closed and then the msafe page will be entered to collect signatures. We will optimize it in future releases.**
 
+Example:
 ```tsx
 import { useWallet, MsafeWalletName } from "@manahippo/aptos-wallet-adapter";
 

--- a/src/JsonRPCServer.ts
+++ b/src/JsonRPCServer.ts
@@ -13,6 +13,11 @@ export class JsonRPCServer {
         const req = parse(data) as JsonRpcPayloadRequest;
         if (req.type !== 'request') return;
         const method = this.methods[req.method];
+        if (method === undefined) {
+            const resp = format.error(req.id, new JsonRpcError("method not exist"));
+            this.connector.send(resp);
+            return;
+        }
         method(...(req.params as JsonRpcParamsSchemaByPositional).map(param => decodeFromStr(param))).then(response => {
             const resp = format.response(req.id, encodeToStr(response));
             this.connector.send(resp);

--- a/tests/JsonRpcCS.test.ts
+++ b/tests/JsonRpcCS.test.ts
@@ -1,0 +1,42 @@
+import { Connector } from "../src/connector";
+import { JsonRPCServer } from "../src/JsonRPCServer";
+import { JsonRPCClient } from "../src/JsonRPCClient";
+
+
+describe("Connector test", () => {
+    const requestName = "ping";
+    const requestData = "anything";
+    const requestDataWrong = "wrong";
+    const notificationName = "sthChange";
+    const notificationData = "something";
+    const channel = new MessageChannel();
+    const server = new JsonRPCServer(new Connector(channel.port1, true), {
+        [requestName]: async (data:string) => {
+            if(data !== requestData) throw data;
+            return "pong";
+        }
+    });
+    const client = new JsonRPCClient(new Connector(channel.port2, true), {
+        [notificationName]: async(data:string)=>{
+            expect(data).toEqual(notificationData);
+        }
+    });
+
+    it("ping-pong", async () => {
+        const result = await client.request(requestName, [requestData]);
+        expect(result).toEqual("pong");
+    })
+
+    it("notification", async () => {
+        await server.notify(notificationName, [notificationData]);
+    })
+
+    it("request error", async () => {
+        await expect(client.request(requestName, [requestDataWrong])).rejects.toEqual(requestDataWrong);
+    });
+
+    it("request not exist", async () => {
+        await expect(client.request("notExist", [])).rejects.toEqual("method not exist");
+    });
+
+});

--- a/tests/MsafeWallet.test.ts
+++ b/tests/MsafeWallet.test.ts
@@ -17,7 +17,7 @@ const TestData = {
     message: "message",
 }
 
-test("MsafeWallet", async () => {
+test("MsafeWallet integration test", async () => {
     const channel = new MessageChannel();
     const msafeServer = new MsafeServer(new Connector(channel.port1, true), {
         async connect(): Promise<Account> {
@@ -86,4 +86,34 @@ test("MsafeWallet", async () => {
     await msafeServer.changeNetwork(TestData.network);
     channel.port1.close();
     channel.port2.close();
+});
+
+describe("MsafeWallet unit test", () => {
+    it("getOrigin test", async () => {
+        const msafeMainnet = MsafeWallet.getOrigin("Mainnet");
+        expect(msafeMainnet).toEqual("https://app.m-safe.io");
+        const msafeTestnet = MsafeWallet.getOrigin("Testnet");
+        expect(msafeTestnet).toEqual("https://testnet.m-safe.io");
+        const msafeLocal = MsafeWallet.getOrigin("http://localhost:3000");
+        expect(msafeLocal).toEqual("http://localhost:3000");
+    });
+
+    it("getAppUrl test", () => {
+        const dappUrl = "https://dapp.io";
+        const msafeMainnetDapp = MsafeWallet.getAppUrl('Mainnet', dappUrl);
+        expect(msafeMainnetDapp).toEqual("https://app.m-safe.io/apps/0?url=https%3A%2F%2Fdapp.io");
+        const msafeTestnetDapp = MsafeWallet.getAppUrl('Testnet', dappUrl);
+        expect(msafeTestnetDapp).toEqual("https://testnet.m-safe.io/apps/0?url=https%3A%2F%2Fdapp.io");
+        const msafeLocalDapp = MsafeWallet.getAppUrl('http://localhost:3000', dappUrl);
+        expect(msafeLocalDapp).toEqual("http://localhost:3000/apps/0?url=https%3A%2F%2Fdapp.io");
+    });
+
+    it("inMsafeWallet test", () => {
+        expect(MsafeWallet.inMsafeWallet()).toEqual(false);
+
+        global.window = {} as any;
+        global.document = {} as any;
+        global.parent = {window:{}} as any;
+        expect(MsafeWallet.inMsafeWallet()).toEqual(true);
+    });
 });

--- a/tests/connector.test.ts
+++ b/tests/connector.test.ts
@@ -1,0 +1,37 @@
+import { Connector } from '../src/connector'
+
+
+test("Connector integration test", async () => {
+    let done : (v:any)=>void;
+    const serverOrigin = 'https://m-safe.io';
+    const clientOrigin = 'https://dapp.io';
+    const fakeWindows = {
+        handle: (ev: MessageEvent) => { },
+        addEventListener: (type = 'message', handle:any) => fakeWindows.handle = handle,
+        removeEventListener: (type = 'message', handle:any) => { fakeWindows.handle = () => { } },
+        postMessage: (message: string, origin = serverOrigin, ports: MessagePort[]) => {
+            fakeWindows.handle(new MessageEvent('message', { data: message, origin: clientOrigin, ports: ports }));
+        }
+    };
+    global.window = fakeWindows as any;
+
+    const cleaner = Connector.accepts(clientOrigin, (connector:Connector)=>{
+        expect(connector.connected).toEqual(true);
+        connector.on("message", (data:any)=>{
+            expect(data).toEqual("ping");
+            connector.send("pong");
+        })
+    });
+    
+    const connector = await Connector.connect(fakeWindows, serverOrigin);
+    cleaner();
+    expect(connector.connected).toEqual(true);
+    connector.on("message", (data:any)=>{
+        expect(data).toEqual("pong");
+        connector.close();
+        done(undefined);
+    });
+    connector.send("ping");
+    
+    return new Promise(resolve => done = resolve);
+});


### PR DESCRIPTION
## Coverage:
```bash
➜  msafe-iframe git:(unit_test) ✗ npx jest --coverage 
 PASS  tests/JsonRpcCS.test.ts
 PASS  tests/MsafeWallet.test.ts
 PASS  tests/coder.test.ts
 PASS  tests/connector.test.ts
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |   91.93 |    78.18 |   87.35 |   94.34 |                   
 JsonRPCClient.ts |   96.15 |      100 |      75 |     100 |                   
 JsonRPCServer.ts |      92 |       50 |   77.77 |     100 | 14                
 MsafeServer.ts   |     100 |      100 |     100 |     100 |                   
 MsafeWallet.ts   |   81.25 |    53.84 |   84.21 |   83.87 | 18-19,90-92       
 WalletAPI.ts     |     100 |      100 |     100 |     100 |                   
 coder.ts         |   97.08 |    95.23 |     100 |   97.95 | 91,178            
 connector.ts     |   81.39 |    63.63 |   73.33 |   84.61 | 11,28,67-70       
------------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        5.039 s, estimated 6 s
Ran all test suites.
```