### PR TITLE
change msafe accountkeys to multisgin form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msafe-wallet",
-  "version": "1.1.9",
+  "version": "2.0.0",
   "description": "appstore sdk of msafe wallet",
   "author": "LeviHHH",
   "license": "MIT",

--- a/src/JsonRPCClient.ts
+++ b/src/JsonRPCClient.ts
@@ -19,11 +19,11 @@ export class JsonRPCClient {
             case 'notification':
                 return this.onNotify(mesg.method, (mesg.params as JsonRpcParamsSchemaByPositional).map(decodeFromStr));
             case 'response':
-                const {resolve} = this.executors[Number(mesg.id)];
+                const { resolve } = this.executors[Number(mesg.id)];
                 delete this.executors[Number(mesg.id)];
                 return resolve(decodeFromStr(mesg.result));
             case 'error':
-                const {reject} = this.executors[Number(mesg.id)];
+                const { reject } = this.executors[Number(mesg.id)];
                 delete this.executors[Number(mesg.id)];
                 return reject(mesg.error.message);
         }

--- a/src/WalletAPI.ts
+++ b/src/WalletAPI.ts
@@ -3,13 +3,13 @@ export interface Account {
     address: string;
     authKey: string;
     minKeysRequired: number;
-  }
+}
 
 export type Option = Partial<{
-    max_gas_amount: string|bigint,
-    gas_unit_price: string|bigint,
-    expiration_timestamp_secs: string|bigint,
-    sequence_number: string|bigint,
+    max_gas_amount: string | bigint,
+    gas_unit_price: string | bigint,
+    expiration_timestamp_secs: string | bigint,
+    sequence_number: string | bigint,
     sender: string,
 }>;
 

--- a/src/WalletAPI.ts
+++ b/src/WalletAPI.ts
@@ -1,7 +1,9 @@
-export type Account = {
-    address: string,
-    publicKey: string,
-}
+export interface Account {
+    publicKey: string[];
+    address: string;
+    authKey: string;
+    minKeysRequired: number;
+  }
 
 export type Option = Partial<{
     max_gas_amount: string|bigint,

--- a/tests/JsonRpcCS.test.ts
+++ b/tests/JsonRpcCS.test.ts
@@ -11,13 +11,13 @@ describe("Connector test", () => {
     const notificationData = "something";
     const channel = new MessageChannel();
     const server = new JsonRPCServer(new Connector(channel.port1, true), {
-        [requestName]: async (data:string) => {
-            if(data !== requestData) throw data;
+        [requestName]: async (data: string) => {
+            if (data !== requestData) throw data;
             return "pong";
         }
     });
     const client = new JsonRPCClient(new Connector(channel.port2, true), {
-        [notificationName]: async(data:string)=>{
+        [notificationName]: async (data: string) => {
             expect(data).toEqual(notificationData);
         }
     });

--- a/tests/MsafeWallet.test.ts
+++ b/tests/MsafeWallet.test.ts
@@ -36,7 +36,7 @@ test("MsafeWallet integration test", async () => {
             return TestData.network;
         },
         async account(): Promise<Account> {
-            if(!TestData.isConnected) throw "unauthorized";
+            if (!TestData.isConnected) throw "unauthorized";
             return TestData.account;
         },
         async chainId(): Promise<Number> {
@@ -75,7 +75,7 @@ test("MsafeWallet integration test", async () => {
     await expect(msafeWallet.signTransaction(TestData.mockTxn)).resolves.toEqual(TestData.mockTxnSigned);
     await msafeWallet.disconnect();
     await expect(msafeWallet.isConnected()).resolves.toEqual(false);
-    
+
     msafeWallet.onChangeAccount((account) => {
         expect(account).toEqual(TestData.account)
     });
@@ -115,7 +115,7 @@ describe("MsafeWallet unit test", () => {
 
         global.window = {} as any;
         global.document = {} as any;
-        global.parent = {window:{}} as any;
+        global.parent = { window: {} } as any;
         expect(MsafeWallet.inMsafeWallet()).toEqual(true);
     });
 });

--- a/tests/MsafeWallet.test.ts
+++ b/tests/MsafeWallet.test.ts
@@ -6,7 +6,9 @@ import { Account, Payload, Option } from '../src/WalletAPI';
 const TestData = {
     account: {
         address: "0xffeeddccbbaa9988776655443322110000112233445566778899aabbccddeeff",
-        publicKey: "0x00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100"
+        publicKey: ["0x00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"],
+        authKey: "0xaa9988776655443322110000112233445566778899aabbccddeeff0011223344",
+        minKeysRequired: 2,
     },
     isConnected: false,
     network: "mainnet",

--- a/tests/coder.test.ts
+++ b/tests/coder.test.ts
@@ -23,7 +23,7 @@ const TestDatas = [
 ];
 
 test("encode/decode", () => {
-    for(const testdata of TestDatas) {
+    for (const testdata of TestDatas) {
         const enc = encode(testdata);
         const de = decode(enc);
         expect(de).toEqual(testdata);
@@ -35,7 +35,7 @@ test("encode/decode", () => {
 
 
 test("encodeToStr/decodeFromStr", () => {
-    for(const testdata of TestDatas) {
+    for (const testdata of TestDatas) {
         const enc = encodeToStr(testdata);
         const de = decodeFromStr(enc);
         expect(de).toEqual(testdata);

--- a/tests/connector.test.ts
+++ b/tests/connector.test.ts
@@ -2,36 +2,36 @@ import { Connector } from '../src/connector'
 
 
 test("Connector integration test", async () => {
-    let done : (v:any)=>void;
+    let done: (v: any) => void;
     const serverOrigin = 'https://m-safe.io';
     const clientOrigin = 'https://dapp.io';
     const fakeWindows = {
         handle: (ev: MessageEvent) => { },
-        addEventListener: (type = 'message', handle:any) => fakeWindows.handle = handle,
-        removeEventListener: (type = 'message', handle:any) => { fakeWindows.handle = () => { } },
+        addEventListener: (type = 'message', handle: any) => fakeWindows.handle = handle,
+        removeEventListener: (type = 'message', handle: any) => { fakeWindows.handle = () => { } },
         postMessage: (message: string, origin = serverOrigin, ports: MessagePort[]) => {
             fakeWindows.handle(new MessageEvent('message', { data: message, origin: clientOrigin, ports: ports }));
         }
     };
     global.window = fakeWindows as any;
 
-    const cleaner = Connector.accepts(clientOrigin, (connector:Connector)=>{
+    const cleaner = Connector.accepts(clientOrigin, (connector: Connector) => {
         expect(connector.connected).toEqual(true);
-        connector.on("message", (data:any)=>{
+        connector.on("message", (data: any) => {
             expect(data).toEqual("ping");
             connector.send("pong");
         })
     });
-    
+
     const connector = await Connector.connect(fakeWindows, serverOrigin);
     cleaner();
     expect(connector.connected).toEqual(true);
-    connector.on("message", (data:any)=>{
+    connector.on("message", (data: any) => {
         expect(data).toEqual("pong");
         connector.close();
         done(undefined);
     });
     connector.send("ping");
-    
+
     return new Promise(resolve => done = resolve);
 });


### PR DESCRIPTION
## Change
1. optimize data coders to reduce memory copy.
2. change the account form to:
```typescript
interface Account {
    publicKey: string[];
    address: string;
    authKey: string;
    minKeysRequired: number;
}
```

adaptor pr: https://github.com/hippospace/aptos-wallet-adapter/pull/110
