### PR TITLE
support allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msafe-wallet",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "appstore sdk of msafe wallet",
   "author": "LeviHHH",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msafe-wallet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "appstore sdk of msafe wallet",
   "author": "LeviHHH",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msafe-wallet",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "appstore sdk of msafe wallet",
   "author": "LeviHHH",
   "license": "MIT",

--- a/src/MsafeWallet.ts
+++ b/src/MsafeWallet.ts
@@ -88,20 +88,11 @@ export class MsafeWallet implements WalletAPI {
         return new URL(MsafeOrigins[msafe as NetworkType] || msafe).origin;
     }
 
-    private static isValidOrigin(msafe: NetworkType | string | string[], msafeOrigin: string): boolean {
-        if(msafe instanceof Array) {
-            return msafe.map(m=>MsafeWallet.getOrigin(m)).includes(msafeOrigin);
-        }
-        return msafeOrigin === MsafeWallet.getOrigin(msafe);
-    }
-
     /// open msafe wallet
     /// @param msafe: network type of msafe website url
     static async new(msafe: NetworkType | string | string[] = 'Mainnet'): Promise<MsafeWallet> {
-        const msafeWindow = window.parent;
-        const msafeOrigin = msafeWindow.origin;
-        if(!MsafeWallet.isValidOrigin(msafe, msafeOrigin)) throw `invalid msafe origin, expected ${msafe}, got ${msafeOrigin}`;
-        const connector = await Connector.connect(msafeWindow, msafeOrigin);
+        const msafeOrigin = msafe instanceof Array ? msafe.map(m=>MsafeWallet.getOrigin(m)) : [MsafeWallet.getOrigin(msafe)];
+        const connector = await Connector.connect(window.parent, msafeOrigin);
         return new MsafeWallet(connector);
     }
 }

--- a/src/MsafeWallet.ts
+++ b/src/MsafeWallet.ts
@@ -88,11 +88,20 @@ export class MsafeWallet implements WalletAPI {
         return new URL(MsafeOrigins[msafe as NetworkType] || msafe).origin;
     }
 
+    private static isValidOrigin(msafe: NetworkType | string | string[], msafeOrigin: string): boolean {
+        if(msafe instanceof Array) {
+            return msafe.map(m=>MsafeWallet.getOrigin(m)).includes(msafeOrigin);
+        }
+        return msafeOrigin === MsafeWallet.getOrigin(msafe);
+    }
+
     /// open msafe wallet
     /// @param msafe: network type of msafe website url
-    static async new(msafe: NetworkType | string = 'Mainnet'): Promise<MsafeWallet> {
-        const msafeOrigin = MsafeWallet.getOrigin(msafe);
-        const connector = await Connector.connect(window.parent, msafeOrigin);
+    static async new(msafe: NetworkType | string | string[] = 'Mainnet'): Promise<MsafeWallet> {
+        const msafeWindow = window.parent;
+        const msafeOrigin = msafeWindow.origin;
+        if(!MsafeWallet.isValidOrigin(msafe, msafeOrigin)) throw `invalid msafe origin, expected ${msafe}, got ${msafeOrigin}`;
+        const connector = await Connector.connect(msafeWindow, msafeOrigin);
         return new MsafeWallet(connector);
     }
 }

--- a/src/MsafeWallet.ts
+++ b/src/MsafeWallet.ts
@@ -5,10 +5,13 @@ type onEventFunc = (data: any) => void
 
 const MsafeOrigins = {
     Mainnet: 'https://app.m-safe.io',
-    Testnet: 'https://testnet.m-safe.io'
+    Testnet: 'https://testnet.m-safe.io',
+    Partner: 'https://partner.m-safe.io',
 };
 
 type NetworkType = keyof typeof MsafeOrigins;
+type MsafeNetwork = NetworkType | string;
+type MsafeNetworks = MsafeNetwork | MsafeNetwork[];
 
 export class MsafeWallet implements WalletAPI {
     public client: JsonRPCClient;
@@ -74,24 +77,25 @@ export class MsafeWallet implements WalletAPI {
             parent.window !== window
     }
 
-    /// get msafe dapp url, which can be used to open dapp under msafe wallet.
-    /// @param msafe: network type of msafe website url
+    /// Get msafe dapp url, which can be used to open dapp under msafe wallet.
+    /// @param msafe: network type or msafe website url
     /// @param dappUrl: dapp url
-    static getAppUrl(msafe: NetworkType | string = 'Mainnet', dappUrl = `${window.location.href}`): string {
+    static getAppUrl(msafe: MsafeNetwork = 'Mainnet', dappUrl = `${window.location.href}`): string {
         const msafeOrigin = MsafeWallet.getOrigin(msafe);
         return `${msafeOrigin}/apps/0?url=${encodeURIComponent(dappUrl)}`;
     }
 
-    /// get msafe origin by network type or url
-    /// @param msafe: network type of msafe website url
-    static getOrigin(msafe: NetworkType | string = 'Mainnet'): string {
+    /// Get msafe origin by network type or url
+    /// @param msafe: network type or msafe website url
+    static getOrigin(msafe: MsafeNetwork = 'Mainnet'): string {
         return new URL(MsafeOrigins[msafe as NetworkType] || msafe).origin;
     }
 
-    /// open msafe wallet
-    /// @param msafe: network type of msafe website url
-    static async new(msafe: NetworkType | string | string[] = 'Mainnet'): Promise<MsafeWallet> {
-        const msafeOrigin = msafe instanceof Array ? msafe.map(m=>MsafeWallet.getOrigin(m)) : [MsafeWallet.getOrigin(msafe)];
+    /// Open msafe wallet and establish communication with the msafe website.
+    /// The allowlist is used to check if the msafe website is trusted.
+    /// @param allowlist: allowlist of msafe website url, omit means accpets all msafe websites. you can pass a single url or an array of urls.
+    static async new(allowlist: MsafeNetworks = Object.values(MsafeOrigins)): Promise<MsafeWallet> {
+        const msafeOrigin = allowlist instanceof Array ? allowlist.map(m=>MsafeWallet.getOrigin(m)) : [MsafeWallet.getOrigin(allowlist)];
         const connector = await Connector.connect(window.parent, msafeOrigin);
         return new MsafeWallet(connector);
     }

--- a/src/MsafeWallet.ts
+++ b/src/MsafeWallet.ts
@@ -3,14 +3,18 @@ import { JsonRPCClient } from "./JsonRPCClient";
 import { Account, WalletAPI, Option, Payload, WalletEvent, WalletRPC } from "./WalletAPI";
 type onEventFunc = (data: any) => void
 
+/// MSafe website urls, it acts as the default allowlist.
 const MsafeOrigins = {
     Mainnet: 'https://app.m-safe.io',
     Testnet: 'https://testnet.m-safe.io',
     Partner: 'https://partner.m-safe.io',
 };
 
+/// Network type of MSafe websites. It can be 'Mainnet', 'Testnet' or 'Partner'. 
 type NetworkType = keyof typeof MsafeOrigins;
+/// NetworkType or MSafe website url.
 type MsafeNetwork = NetworkType | string;
+/// MsafeNetwork or array of MsafeNetwork.
 type MsafeNetworks = MsafeNetwork | MsafeNetwork[];
 
 export class MsafeWallet implements WalletAPI {
@@ -94,6 +98,18 @@ export class MsafeWallet implements WalletAPI {
     /// Open msafe wallet and establish communication with the msafe website.
     /// The allowlist is used to check if the msafe website is trusted.
     /// @param allowlist: allowlist of msafe website url, omit means accpets all msafe websites. you can pass a single url or an array of urls.
+    /// @returns MsafeWallet instance
+    /// Example:
+    /// 1. Iinitialize MsafeWallet with default allowlist:
+    ///     const wallet = await MsafeWallet.new();
+    /// 2. Iinitialize MsafeWallet with a single MSafe url:
+    ///     const wallet = await MsafeWallet.new('https://app.m-safe.io');
+    /// 3. Iinitialize MsafeWallet with an array of MSafe urls:
+    ///     const wallet = await MsafeWallet.new(['https://app.m-safe.io', 'https://testnet.m-safe.io', 'https://partner.m-safe.io']);
+    /// 4. Iinitialize MsafeWallet with a single network type:
+    ///     const wallet = await MsafeWallet.new('Mainnet');
+    /// 5. Iinitialize MsafeWallet with an array of network types:
+    ///     const wallet = await MsafeWallet.new(['Mainnet', 'Testnet', 'Partner']);
     static async new(allowlist: MsafeNetworks = Object.values(MsafeOrigins)): Promise<MsafeWallet> {
         const msafeOrigin = allowlist instanceof Array ? allowlist.map(m=>MsafeWallet.getOrigin(m)) : [MsafeWallet.getOrigin(allowlist)];
         const connector = await Connector.connect(window.parent, msafeOrigin);

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,4 +1,5 @@
 import { version } from '../package.json';
+import { IsAllowList } from './version';
 
 export class Connector {
     static version = version;
@@ -53,34 +54,19 @@ export class Connector {
         return data.startsWith(handshakeType);
     }
 
-    static getHandshakeVersion(data: string) {
+    static getVersionFromHandshake(data: string) {
         return String(data).split(':')[1];
     }
 
-    static toHandshakeVersion(handshakeType: string, withVersion = true) {
+    static toHandshakeMessage(handshakeType: string, withVersion = true) {
         return withVersion ? `${handshakeType}:${Connector.version}` : handshakeType;
     }
 
     // client connect to server
-    static async connect_deprecated(targetWindow: any, origin: string): Promise<Connector> {
-        return new Promise((resolve, rejected) => {
-            const channelPair = new MessageChannel();
-            let timer = setTimeout(rejected, 1000);
-            channelPair.port1.onmessage = ev => {
-                if (Connector.isHandshakeMessage(ev.data, Connector.HANDSHAKE_ACK)) {
-                    clearTimeout(timer);
-                    const version = Connector.getHandshakeVersion(ev.data);
-                    resolve(new Connector(channelPair.port1, version));
-                }
-            };
-            targetWindow.postMessage(Connector.toHandshakeVersion(Connector.HANDSHAKE_REQ), origin, [channelPair.port2]);
-        });
-    }
-    // client connect to server
     static async connect(targetWindow: any, origins: string[]): Promise<Connector> {
         return new Promise((resolve, rejected) => {
-            let cleaner = () => {};
-            let timer = setTimeout(()=>{
+            let cleaner = () => { };
+            let timer = setTimeout(() => {
                 cleaner();
                 rejected('connect timeout');
             }, 1000);
@@ -89,7 +75,7 @@ export class Connector {
                 if (!origins.includes(ev.origin)) return;
                 if (!Connector.isHandshakeMessage(ev.data, Connector.HANDSHAKE_PORT_ACK)) return;
                 cleaner();
-                const version = Connector.getHandshakeVersion(ev.data);
+                const version = Connector.getVersionFromHandshake(ev.data);
                 resolve(new Connector(port, version));
             };
             cleaner = () => {
@@ -97,23 +83,23 @@ export class Connector {
                 window.removeEventListener('message', handle);
             };
             window.addEventListener('message', handle);
-            targetWindow.postMessage(Connector.toHandshakeVersion(Connector.HANDSHAKE_REQ), '*');
+            targetWindow.postMessage(Connector.toHandshakeMessage(Connector.HANDSHAKE_REQ), '*');
         });
     }
     // server listening connection request
-    static accepts(origin: string, fallback: (connector: Connector) => void): () => void {
+    static accepts(origin: string, handler: (connector: Connector) => void): () => void {
         const handle = (ev: MessageEvent) => {
             if (ev.origin !== origin) return;
             if (!Connector.isHandshakeMessage(ev.data, Connector.HANDSHAKE_REQ)) return;
-            const version = Connector.getHandshakeVersion(ev.data);
-            const port = ev.ports[0];
-            if(port) {
-                port.postMessage(Connector.toHandshakeVersion(Connector.HANDSHAKE_ACK, version !== undefined));
-                fallback(new Connector(ev.ports[0], version));
-            } else {
+            const version = Connector.getVersionFromHandshake(ev.data);
+            if (IsAllowList(version)) {
                 const channelPair = new MessageChannel();
-                (ev.source as Window).postMessage(Connector.toHandshakeVersion(Connector.HANDSHAKE_PORT_ACK), ev.origin, [channelPair.port2]);
-                fallback(new Connector(channelPair.port1, version));
+                (ev.source as Window).postMessage(Connector.toHandshakeMessage(Connector.HANDSHAKE_PORT_ACK), ev.origin, [channelPair.port2]);
+                handler(new Connector(channelPair.port1, version));
+            } else {
+                const port = ev.ports[0];
+                port.postMessage(Connector.toHandshakeMessage(Connector.HANDSHAKE_ACK, version !== undefined));
+                handler(new Connector(ev.ports[0], version));
             }
         };
         window.addEventListener('message', handle);

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -88,6 +88,7 @@ export class Connector {
     }
     // server listening connection request
     static accepts(origin: string, handler: (connector: Connector) => void): () => void {
+        origin = new URL(origin).origin;
         const handle = (ev: MessageEvent) => {
             if (ev.origin !== origin) return;
             if (!Connector.isHandshakeMessage(ev.data, Connector.HANDSHAKE_REQ)) return;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 
 
 enum Version {
-    ALLOWLIST = '2.0.4',
+    ALLOWLIST = '2.0.5',
 };
 
 /// Compare two version strings.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 
-
+/// Versions that introduces new features.
 enum Version {
-    ALLOWLIST = '2.0.5',
+    ALLOWLIST = '2.0.5', // version that enable allowlist
 };
 
 /// Compare two version strings.
@@ -20,5 +20,5 @@ export function cmp(a: string, b: string): number {
 
 /// Check if the version is enable allowlist.
 export function IsAllowList(version: string): boolean {
-    return version !== undefined && cmp(version as Version, Version.ALLOWLIST) >= 0;
+    return version !== undefined && cmp(version, Version.ALLOWLIST) >= 0;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,24 @@
+
+
+enum Version {
+    ALLOWLIST = '2.0.4',
+};
+
+/// Compare two version strings.
+export function cmp(a: string, b: string): number {
+    const parse = (version: string) => version.split('.').map(Number);
+    const [majorA, minorA, batchA] = parse(a);
+    const [majorB, minorB, batchB] = parse(b);
+    if (majorA > majorB) return 1;
+    if (majorA < majorB) return -1;
+    if (minorA > minorB) return 1;
+    if (minorA < minorB) return -1;
+    if (batchA > batchB) return 1;
+    if (batchA < batchB) return -1;
+    return 0;
+}
+
+/// Check if the version is enable allowlist.
+export function IsAllowList(version: string): boolean {
+    return version !== undefined && cmp(version as Version, Version.ALLOWLIST) >= 0;
+}

--- a/tests/connector.test.ts
+++ b/tests/connector.test.ts
@@ -2,18 +2,71 @@ import { Connector } from '../src/connector'
 
 const serverOrigin = 'https://m-safe.io';
 const clientOrigin = 'https://dapp.io';
-const fakeWindows = {
-    handle: (ev: MessageEvent) => { },
-    addEventListener: (type = 'message', handle: any) => fakeWindows.handle = handle,
-    removeEventListener: (type = 'message', handle: any) => { fakeWindows.handle = () => { } },
-    postMessage: (message: string, origin: string, ports: MessagePort[]) => {
-        fakeWindows.handle(new MessageEvent('message', { data: message, origin: clientOrigin, ports: ports }));
+const invalidOrigin = 'https://invalid.io';
+
+/// We use FakeMessageEvent to simulate MessageEvent, because MessageEvent check source type is Window.
+class FakeMessageEvent {
+    data:any;
+    origin:string;
+    source:any;
+    ports:any[];
+    constructor(message:any, option:any) {
+        if(message !== 'message') throw new Error('invalid message');
+        this.data = option.data;
+        this.origin = option.origin;
+        this.source = option.source;
+        this.ports = option.ports || [];
+    }
+}
+
+type EventHandler = (ev: FakeMessageEvent) => void;
+/// We use FakeWindow to simulate multiply window object, because jest doesn't support child iframe.
+class FakeWindows {
+    origin: string;
+    targetWindow!: FakeWindows;
+    ports: MessagePort[] = [];
+    handle?: EventHandler;
+    constructor(origin: string) {
+        this.origin = origin;
+    }
+    setTargetWindow(targetWindow: FakeWindows) {
+        this.targetWindow = targetWindow;
+    }
+
+    addEventListener(type = 'message', handle: EventHandler) {
+        this.handle = handle;
+    }
+    removeEventListener(type = 'message', handle: EventHandler) {
+        this.handle = undefined;
+    }
+    postMessage(message: string, origin: string, ports?: MessagePort[]) {
+        ports && this.ports.push(...ports);
+        if (origin === '*' || origin === this.origin) {
+            this.handle && this.handle(new FakeMessageEvent('message', {
+                data: message, origin: this.targetWindow.origin, ports: ports, source: this.targetWindow as any
+            }));
+        }
+    }
+    clean() {
+        this.ports.forEach(port => port.close());
+        this.ports = [];
+        this.handle = undefined;
     }
 };
-global.window = fakeWindows as any;
+
+const serverWindow = new FakeWindows(serverOrigin);
+const clientWindow = new FakeWindows(clientOrigin);
+serverWindow.setTargetWindow(clientWindow);
+clientWindow.setTargetWindow(serverWindow);
+
+/// switch to server/client window
+const switchToServer = () => global.window = serverWindow as any;
+const switchToClient = () => global.window = clientWindow as any;
 
 test("Connector integration test", async () => {
     let done: (v: any) => void;
+
+    switchToServer();
     const cleaner = Connector.accepts(clientOrigin, (connector: Connector) => {
         expect(connector.connected).toEqual(true);
         connector.on("message", (data: any) => {
@@ -21,27 +74,66 @@ test("Connector integration test", async () => {
             connector.send("pong");
         })
     });
+    switchToClient();
+    const connector = await Connector.connect(serverWindow, [invalidOrigin, serverOrigin]);
 
-    const connector = await Connector.connect(fakeWindows, serverOrigin);
+    switchToServer();
     cleaner();
     expect(connector.connected).toEqual(true);
     connector.on("message", (data: any) => {
         expect(data).toEqual("pong");
-        connector.close();
         done(undefined);
     });
     connector.send("ping");
 
-    return new Promise(resolve => done = resolve);
+    await new Promise(resolve => done = resolve);
+    serverWindow.clean();
+    clientWindow.clean();
 });
 
 describe("Connector unit test", () => {
-    it("connect with client has version", async () => {
+
+    afterEach(() => {
+        serverWindow.clean();
+        clientWindow.clean();
+    });
+
+    it("connect with invalid origins", async () => {
+        switchToServer();
         const cleaner = Connector.accepts(clientOrigin, (connector: Connector) => {
             expect(connector.version.peer).toEqual(connector.version.self);
         });
 
-        const connector = await Connector.connect(fakeWindows, serverOrigin);
+        switchToClient();
+        await expect(Connector.connect(serverWindow, [invalidOrigin])).rejects.toEqual('connect timeout');
+        switchToServer();
+        cleaner();
+    });
+
+    it("connect with client use old handshake", async () => {
+        switchToServer();
+        const cleaner = Connector.accepts(clientOrigin, (connector: Connector) => {
+            expect(connector.version.peer).toEqual(connector.version.self);
+        });
+
+        switchToClient();
+        const connector = await Connector.connect_deprecated(serverWindow, serverOrigin);
+        switchToServer();
+        cleaner();
+        // check version
+        expect(connector.version.peer).toEqual(connector.version.self);
+        connector.close();
+    });
+
+    it("connect with client has version", async () => {
+        switchToServer();
+        const cleaner = Connector.accepts(clientOrigin, (connector: Connector) => {
+            expect(connector.version.peer).toEqual(connector.version.self);
+        });
+
+        switchToClient();
+        const connector = await Connector.connect(serverWindow, [serverOrigin]);
+        switchToServer();
         cleaner();
         // check version
         expect(connector.version.peer).toEqual(connector.version.self);
@@ -49,24 +141,27 @@ describe("Connector unit test", () => {
     });
 
     it("connect with client without version", async () => {
+        switchToServer();
         const cleaner = Connector.accepts(clientOrigin, (connector: Connector) => {
             expect(connector.version.peer).toEqual(undefined);
         });
 
-        const postMessage = fakeWindows.postMessage;
-        fakeWindows.postMessage = (message: string, origin: string, ports: MessagePort[]) => {
+        const postMessage = serverWindow.postMessage.bind(serverWindow);
+        serverWindow.postMessage = (message: string, origin: string, ports: MessagePort[]) => {
             if (Connector.isHandshakeMessage(message, Connector.HANDSHAKE_REQ)) {
                 message = Connector.toHandshakeVersion(Connector.HANDSHAKE_REQ, false);
             }
             return postMessage(message, origin, ports);
         }
 
-        const connector = await Connector.connect(fakeWindows, serverOrigin);
+        switchToClient();
+        const connector = await Connector.connect_deprecated(serverWindow, serverOrigin);
+        switchToServer();
         cleaner();
 
         // check version
         expect(connector.version.peer).toEqual(undefined);
         connector.close();
+        serverWindow.postMessage = postMessage;
     });
-
 });

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -11,9 +11,9 @@ describe('version', () => {
         expect(cmp('2.0.4', '3.6.9')).toEqual(-1);
     });
     it('IsAllowList', () => {
-        expect(IsAllowList('2.0.4')).toEqual(true);
-        expect(IsAllowList('2.0.3')).toEqual(false);
         expect(IsAllowList('2.0.5')).toEqual(true);
+        expect(IsAllowList('2.0.4')).toEqual(false);
+        expect(IsAllowList('2.0.6')).toEqual(true);
         expect(IsAllowList('2.1.1')).toEqual(true);
         expect(IsAllowList('1.6.4')).toEqual(false);
         expect(IsAllowList('3.6.9')).toEqual(true);

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,21 @@
+import {cmp, IsAllowList} from '../src/version';
+
+describe('version', () => {
+    it('cmp', () => {
+        expect(cmp('2.0.4', '2.0.4')).toEqual(0);
+        expect(cmp('2.0.4', '2.0.3')).toEqual(1);
+        expect(cmp('2.0.12', '2.0.3')).toEqual(1);
+        expect(cmp('2.0.4', '2.0.5')).toEqual(-1);
+        expect(cmp('2.0.4', '2.1.1')).toEqual(-1);
+        expect(cmp('2.0.4', '1.6.4')).toEqual(1);
+        expect(cmp('2.0.4', '3.6.9')).toEqual(-1);
+    });
+    it('IsAllowList', () => {
+        expect(IsAllowList('2.0.4')).toEqual(true);
+        expect(IsAllowList('2.0.3')).toEqual(false);
+        expect(IsAllowList('2.0.5')).toEqual(true);
+        expect(IsAllowList('2.1.1')).toEqual(true);
+        expect(IsAllowList('1.6.4')).toEqual(false);
+        expect(IsAllowList('3.6.9')).toEqual(true);
+    });
+});


### PR DESCRIPTION
support allowlist that allow msafe-wallet to specify an array of origins.
TODO:
- Apply this feature to HippoAdapter
- Integrate testing in a racet demo project.